### PR TITLE
fix: Support unorthodox Maven coordinates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ impl<'a> MavenCoordinates<'a> {
     /// ```
     pub fn parse(maven_coordinates: &str) -> Result<MavenCoordinates, Error> {
         // Parse Maven coordinates into named capture groups, with optional packaging OR packaging+classifier
-        let regexp = Regex::new(r"^(?P<groupId>[\w.]+):(?P<artifactId>[\w.\-]+)(?:(?::(?P<packaging>[\w]+))(?::(?P<classifier>[\w]+)?)?)?:(?P<version>[\w.\-]+)$").unwrap();
+        let regexp = Regex::new(r"^(?P<groupId>[\w.\-]+):(?P<artifactId>[\w.\-]+)(?:(?::(?P<packaging>[\w.\-]+))(?::(?P<classifier>[\w.\-]+)?)?)?:(?P<version>[\w.\-]+)$").unwrap();
         let matches = regexp.captures(maven_coordinates).unwrap();
 
         Ok(MavenCoordinates {
@@ -114,6 +114,19 @@ mod tests {
             packaging: Some("jar"),
             classifier: Some("sources"),
             version: "2.9.9",
+        };
+        assert_eq!(MavenCoordinates::parse(provided).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_parse_unorthodox_maven_coordinate() {
+        let provided = "io.get-coursier:coursier-cli_2.12:jar:standalone:1.1.0-M14-4";
+        let expected = MavenCoordinates {
+            group_id: "io.get-coursier",
+            artifact_id: "coursier-cli_2.12",
+            packaging: Some("jar"),
+            classifier: Some("standalone"),
+            version: "1.1.0-M14-4",
         };
         assert_eq!(MavenCoordinates::parse(provided).unwrap(), expected);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,11 @@ extern crate clap;
 use clap::{App, Arg, SubCommand};
 use rvn::{MavenCoordinates};
 
+const RVN_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 fn main() {
     let matches = App::new("raven")
-        .version("0.1.1")
+        .version(RVN_VERSION)
         .author("Sebastian Mandrean <sebastian.mandrean@gmail.com>")
         .about("A CLI tool for interacting with Maven repositories & artifacts")
         .subcommand(SubCommand::with_name("checksum")


### PR DESCRIPTION
While [Maven says](https://maven.apache.org/guides/mini/guide-naming-conventions.html) the `groupId` should follow Java package naming rules:

>A group ID should follow Java's package name rules. This means it starts with a reversed domain name you control.

And the [Java's package name rules](https://docs.oracle.com/javase/specs/jls/se6/html/packages.html#7.7) states that hyphens should be converted to underscore:

>If the domain name contains a hyphen, or any other special character not allowed in an identifier (§3.8), convert it into an underscore.

not all artifacts actually do this, for example:
`io.get-coursier:coursier-cli_2.12:jar:standalone:1.1.0-M14-4`

This PR fixes the parsing to work with that as well, adds a unit test to verify the changes, and improves error handling.