### PR TITLE
build: Use strum v0.16.0 from refactor branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,8 +962,8 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "strum 0.15.0 (git+https://github.com/Peternator7/strum?rev=efed58502a40ac101691068bbc6c20a0b351f3fd)",
- "strum_macros 0.15.0 (git+https://github.com/Peternator7/strum?rev=efed58502a40ac101691068bbc6c20a0b351f3fd)",
+ "strum 0.16.0 (git+https://github.com/Peternator7/strum?branch=refactor)",
+ "strum_macros 0.15.0 (git+https://github.com/Peternator7/strum?branch=refactor)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1092,18 +1092,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strum"
-version = "0.15.0"
-source = "git+https://github.com/Peternator7/strum?rev=efed58502a40ac101691068bbc6c20a0b351f3fd#efed58502a40ac101691068bbc6c20a0b351f3fd"
+version = "0.16.0"
+source = "git+https://github.com/Peternator7/strum?branch=refactor#80b576cc47e213a696e72f7e2181b1995787cd07"
 
 [[package]]
 name = "strum_macros"
 version = "0.15.0"
-source = "git+https://github.com/Peternator7/strum?rev=efed58502a40ac101691068bbc6c20a0b351f3fd#efed58502a40ac101691068bbc6c20a0b351f3fd"
+source = "git+https://github.com/Peternator7/strum?branch=refactor#80b576cc47e213a696e72f7e2181b1995787cd07"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1586,8 +1586,8 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum strum 0.15.0 (git+https://github.com/Peternator7/strum?rev=efed58502a40ac101691068bbc6c20a0b351f3fd)" = "<none>"
-"checksum strum_macros 0.15.0 (git+https://github.com/Peternator7/strum?rev=efed58502a40ac101691068bbc6c20a0b351f3fd)" = "<none>"
+"checksum strum 0.16.0 (git+https://github.com/Peternator7/strum?branch=refactor)" = "<none>"
+"checksum strum_macros 0.15.0 (git+https://github.com/Peternator7/strum?branch=refactor)" = "<none>"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ clap = "2.33.0"
 log = "0.4"
 regex = "1"
 reqwest = "0.9.20"
-strum = { git = "https://github.com/Peternator7/strum", rev = "efed58502a40ac101691068bbc6c20a0b351f3fd" }
-strum_macros = { git = "https://github.com/Peternator7/strum", rev = "efed58502a40ac101691068bbc6c20a0b351f3fd" }
+strum = { version = "0.16.0", git = "https://github.com/Peternator7/strum", branch = "refactor" }
+strum_macros = { version = "0.15.0", git = "https://github.com/Peternator7/strum", branch = "refactor" }
 url = "2.1.0"
 
 [profile.release]


### PR DESCRIPTION
Only pinning on git revision apparently isn't allowed when publishing to crates.io.

![image](https://user-images.githubusercontent.com/4631744/64134370-a3bc3d80-cddd-11e9-8769-deace80d2ab9.png)

This PR uses `v0.16.0` of `strum` from the `refactor` branch.